### PR TITLE
added functionality to filter by genre. also made 'Our Theaters' in footer clickable links

### DIFF
--- a/Ticketing/context_processors.py
+++ b/Ticketing/context_processors.py
@@ -1,0 +1,7 @@
+from .models import Theater
+
+# Adding a context processor saves us from having to include "theater = Theater.objects.all()" in every single view
+def all_theaters(request):  
+    return {
+        'theaters': Theater.objects.all()
+    }

--- a/Ticketing/views.py
+++ b/Ticketing/views.py
@@ -68,8 +68,28 @@ def profile_view(request):
     })
 
 def movie_list(request):
+    theater_id = request.GET.get('theater')
+    genre_filter = request.GET.get('genre')
+
     movies = Movie.objects.filter(is_currently_playing=True)
-    return render(request, 'movies/movie_list.html', {'movies': movies, 'title': 'Now Playing'})
+
+    if theater_id:
+        movies = movies.filter(showtimes__theater_id=theater_id)
+
+    if genre_filter:
+        movies = movies.filter(genre=genre_filter)
+
+    movies = movies.distinct()  # Movies can have multiple showtimes and thus appear more than once - we use distinct() to remove dups.
+
+    theaters = Theater.objects.all()
+    genres = Movie.objects.values_list('genre', flat=True).distinct()
+
+    return render(request, 'movies/movie_list.html', {
+        'movies': movies,
+        'theaters': theaters,
+        'genres': genres,
+        'title': 'Now Playing'
+    })
 
 def upcoming_movies(request):
     movies = Movie.objects.filter(is_currently_playing=False, 

--- a/West_Texas_Tickets/settings.py
+++ b/West_Texas_Tickets/settings.py
@@ -45,6 +45,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'Ticketing.context_processors.all_theaters',
             ],
         },
     },

--- a/templates/base.html
+++ b/templates/base.html
@@ -92,12 +92,13 @@
                 <div class="col-md-4">
                     <h5>Our Theaters</h5>
                     <ul class="list-unstyled">
-                        <li>Lubbock</li>
-                        <li>Amarillo</li>
-                        <li>Levelland</li>
-                        <li>Plainview</li>
-                        <li>Snyder</li>
-                        <li>Abilene</li>
+                        {% for theater in theaters %}    <!-- 'Our Theaters' in our footer will now reflect all theaters in our DB instead of being hardcoded. Also, they are now links that take you to that location's theater to see the movies being shown at the specific theater. -->
+                        <li>
+                            <a href="{% url 'movie_list' %}?theater={{ theater.id }}" class="text-white">
+                                {{ theater.location }}
+                            </a>
+                        </li>
+                        {% endfor %}
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Added 2 features:
1. Movies are now able to be sorted/filtered by genre.
2. The theater names in the footer are now clickable links that will take users to that location's theater information - for example it will show only the movies playing in 'Amarillo' 

Changes:
- Changed movie_list view function 
- Changed base.html so that the page displays the theater locations dynamically according to what we have included in our 
   DB as opposed to hardcoding each of the locations.
- Updated `urls.py` with `/poster/<movie_id>/`
- Added context processor for theaters so that we won't have to include the code in every view

The functionality should be testing by ensuring that movies appropriately get filtered by their respective genre. Also, filter by location first, then by genre and see if it still works, etc. I did this but wouldn't hurt to test more extensively.
