### PR TITLE
Filter & Lock Theater Selection on Movie Detail Page

### DIFF
--- a/templates/movies/movie_detail.html
+++ b/templates/movies/movie_detail.html
@@ -49,11 +49,17 @@
             <div class="row g-3">
                 <div class="col-md-4">
                     <label for="theater" class="form-label">Theater Location</label>
-                    <select class="form-select" id="theater" name="theater">
-                        <option value="">All Locations</option>
-                        {% for theater in theaters %}
-                        <option value="{{ theater.id }}">{{ theater.name }} - {{ theater.location }}</option>
-                        {% endfor %}
+                    <select class="form-select" id="theater" name="theater" {% if selected_theater %}disabled{% endif %}>
+                        {% if selected_theater %}
+                            <option value="{{ selected_theater.id }}" selected> 
+                                {{ selected_theater.location }} 
+                            </option>
+                        {%else %}
+                            <option value="">All Locations</option>
+                            {% for theater in theaters %}
+                                <option value="{{ theater.id }}">{{ theater.name }} - {{ theater.location }}</option>
+                            {% endfor %}
+                        {% endif %}
                     </select>
                 </div>
                 <div class="col-md-4">
@@ -64,6 +70,11 @@
                         <option value="{{ date.datetime|date:'Y-m-d' }}">{{ date.datetime|date:"F j, Y" }}</option>
                         {% endfor %}
                     </select>
+
+                    {% if selected_theater %}
+                        <input type="hidden" name="theater" value="{{ selected_theater.id }}">  <!-- Still submit the theater ID using a hidden input -->
+                    {% endif %}
+
                 </div>
                 <div class="col-md-4">
                     <label for="time" class="form-label">Time</label>

--- a/templates/movies/movie_list.html
+++ b/templates/movies/movie_list.html
@@ -48,7 +48,11 @@
                     {% endif %}
                 </div>
                 <div class="card-footer">
-                    <a href="{% url 'movie_detail' movie.id %}" class="btn btn-outline-primary w-100">View Details</a>
+                    {% if selected_theater %}
+                        <a href="{% url 'movie_detail' movie.id %}?theater={{ selected_theater.id }}" class="btn btn-outline-primary w-100">View Details</a>
+                    {% else %}
+                        <a href="{% url 'movie_detail' movie.id %}" class="btn btn-outline-primary w-100">View Details</a>
+                    {% endif %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Changes made:
- Fixed issue where movies didn't uphold the selected theater filter on the movie details page.
- Added logic to pass the theater ID through the URL to keep track of what theater the user filtered by
- Locked theater dropdown menu if the user decides to filter by location. This is to prevent users from changing the location 
   after filtering.